### PR TITLE
Feature/#3 firebase UI auth page

### DIFF
--- a/lib/login/auth_gate.dart
+++ b/lib/login/auth_gate.dart
@@ -1,0 +1,28 @@
+import 'package:digit_kttn/main.dart';
+import 'package:firebase_auth/firebase_auth.dart' hide EmailAuthProvider;
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:flutter/material.dart';
+
+class AuthGate extends StatelessWidget {
+  const AuthGate({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: FirebaseAuth.instance.authStateChanges(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return SignInScreen(
+            providers: [
+              EmailAuthProvider(),
+            ],
+          );
+        }
+
+        return const MyHomePage(
+          title: '',
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:digit_kttn/firebase_options.dart';
+import 'package:digit_kttn/login/auth_gate.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
@@ -19,25 +20,9 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+        primaryColor: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const AuthGate(),
     );
   }
 }


### PR DESCRIPTION

## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/3)

## やったこと

- このプルリクで何をしたのか？
firebase標準のログインページ、サインインページ、パスワード忘れページの実装

## やらないこと

- なし

## できるようになること（ユーザ目線）

- サインイン、ログイン、パスワードの再設定

## できなくなること（ユーザ目線）

- なし

## 動作確認

- どのような動作確認を行ったのか？ 結果はどうか？

https://github.com/user-attachments/assets/1cd263a7-704f-4919-89d7-c6f0c95ff1b4

https://github.com/user-attachments/assets/390260b8-c5ae-4668-93a5-f57fcd1b3f1f