### PR TITLE
add:Sign outボタンの設置、minSdkVersionの修正(android使用時のエラー解消のため)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,7 +41,8 @@ android {
         applicationId = "com.example.digit_kttn"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdk = flutter.minSdkVersion
+        // minSdk = flutter.minSdkVersion
+        minSdkVersion 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName

--- a/lib/login/auth_gate.dart
+++ b/lib/login/auth_gate.dart
@@ -1,4 +1,4 @@
-import 'package:digit_kttn/main.dart';
+import 'package:digit_kttn/root/root_page.dart';
 import 'package:firebase_auth/firebase_auth.dart' hide EmailAuthProvider;
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
@@ -19,9 +19,7 @@ class AuthGate extends StatelessWidget {
           );
         }
 
-        return const MyHomePage(
-          title: '',
-        );
+        return const RootPage();
       },
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:digit_kttn/firebase_options.dart';
 import 'package:digit_kttn/login/auth_gate.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -29,16 +30,6 @@ class MyApp extends StatelessWidget {
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
   final String title;
 
   @override

--- a/lib/root/root_page.dart
+++ b/lib/root/root_page.dart
@@ -1,0 +1,31 @@
+import 'package:digit_kttn/main.dart';
+import 'package:firebase_ui_auth/firebase_ui_auth.dart';
+import 'package:flutter/material.dart';
+
+class RootPage extends StatefulWidget {
+  const RootPage({super.key});
+
+  @override
+  State<RootPage> createState() => _RootPageState();
+}
+
+class _RootPageState extends State<RootPage> {
+  // int _selectedIndex = 0;
+  final pages = [
+    const MyHomePage(
+      title: '',
+    ),
+    // const ProfilePage()
+  ];
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(actions: const [
+        SignOutButton(
+          variant: ButtonVariant.text,
+        )
+      ]),
+      body: pages[0],
+    );
+  }
+}


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/5)

## やったこと

- Sign Outボタンの設置
- minSdkVersionの修正(Android Emulator使用時のエラー修正)

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

<img width="677" alt="スクリーンショット 2025-03-06 18 11 10" src="https://github.com/user-attachments/assets/597f0a3d-4587-402a-bec1-43da7e6fac68" />

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
