### PR TITLE
fix:root_pageの画面表示、簡易的なMap UIの作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:digit_kttn/firebase_options.dart';
 import 'package:digit_kttn/login/auth_gate.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -15,7 +14,6 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -24,84 +22,6 @@ class MyApp extends StatelessWidget {
         primaryColor: Colors.blue,
       ),
       home: const AuthGate(),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/map/map.dart
+++ b/lib/map/map.dart
@@ -1,0 +1,32 @@
+import 'package:digit_kttn/chat/chat.dart';
+import 'package:flutter/material.dart';
+
+// Map画面です。ここを編集してください。
+// 今は簡易的にボタンを配置して押したらChat画面に遷移するようにしています。
+// ボタンが駅のイメージです。
+
+class MapScreen extends StatefulWidget {
+  const MapScreen({super.key});
+
+  @override
+  State<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends State<MapScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        child: IconButton(
+          icon: const Icon(Icons.location_on, color: Colors.red, size: 40),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => ChatScreen()),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/root/root_page.dart
+++ b/lib/root/root_page.dart
@@ -1,4 +1,4 @@
-import 'package:digit_kttn/main.dart';
+import 'package:digit_kttn/map/map.dart';
 import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 import 'package:flutter/material.dart';
 
@@ -10,13 +10,6 @@ class RootPage extends StatefulWidget {
 }
 
 class _RootPageState extends State<RootPage> {
-  // int _selectedIndex = 0;
-  final pages = [
-    const MyHomePage(
-      title: '',
-    ),
-    // const ProfilePage()
-  ];
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -25,7 +18,7 @@ class _RootPageState extends State<RootPage> {
           variant: ButtonVariant.text,
         )
       ]),
-      body: pages[0],
+      body: const MapScreen(),
     );
   }
 }


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/9)

## やったこと

- root_pageの画面表示、簡易的なMap UIの作成

## やらないこと

- デザイン通りのMap UIの実装

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認


https://github.com/user-attachments/assets/54e7effd-f467-4bab-9f7e-a127c55eb202



## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
