### PR TITLE
add:timeline_function

### DIFF
--- a/lib/map/bottom_widget.dart
+++ b/lib/map/bottom_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:digit_kttn/map/map_screen.dart';
 import 'package:flutter/material.dart';
 
@@ -9,6 +10,14 @@ class BottomWidget extends StatefulWidget {
 }
 
 class _BottomWidgetState extends State<BottomWidget> {
+  // FirestoreからStation_Chatsを取得（created_messageの新着順）
+  Stream<QuerySnapshot> getChats() {
+    return FirebaseFirestore.instance
+        .collection('station_chats')
+        .orderBy('created_message', descending: true)
+        .snapshots();
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -39,9 +48,7 @@ class _BottomWidgetState extends State<BottomWidget> {
                     border: InputBorder.none,
                     icon: Icon(Icons.search),
                   ),
-                  onSubmitted: (value) {
-                    // 検索バーに入力された値を処理する
-                  },
+                  onSubmitted: (value) {},
                 ),
               ),
             ),
@@ -53,18 +60,37 @@ class _BottomWidgetState extends State<BottomWidget> {
                   (BuildContext context, ScrollController scrollController) {
                 return Container(
                   color: Colors.white,
-                  child: ListView.builder(
-                    controller: scrollController,
-                    itemCount: 20, // コメントの数に応じて変更
-                    itemBuilder: (BuildContext context, int index) {
-                      return ListTile(
-                        leading: CircleAvatar(
-                          backgroundImage:
-                              AssetImage('assets/images/default_icon.png'),
-                        ),
-                        title: Text(
-                            'Dummy comment $index - This is a sample comment.'),
-                        subtitle: Text('${index + 1} days ago'),
+                  child: StreamBuilder<QuerySnapshot>(
+                    stream: getChats(),
+                    builder: (context, snapshot) {
+                      if (!snapshot.hasData) {
+                        return Center(child: CircularProgressIndicator());
+                      }
+
+                      var chats = snapshot.data!.docs;
+
+                      if (chats.isEmpty) {
+                        return Center(child: Text('投稿がありません'));
+                      }
+
+                      return ListView.builder(
+                        controller: scrollController,
+                        itemCount: chats.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          var chat =
+                              chats[index].data() as Map<String, dynamic>;
+
+                          return ListTile(
+                            leading: CircleAvatar(
+                              backgroundImage:
+                                  AssetImage('assets/images/default_icon.png'),
+                            ),
+                            title: Text(chat['message'] ?? 'メッセージなし'),
+                            subtitle: Text(chat['created_message'] != null
+                                ? chat['created_message'].toDate().toString()
+                                : '日時不明'),
+                          );
+                        },
                       );
                     },
                   ),


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/25)

## やったこと

- timeline機能の追加

## やらないこと

- なし

## できるようになること（ユーザ目線）

- firestore consoleで作成したrecordを新着順で画面下のタイムラインを見ることができる

## できなくなること（ユーザ目線）

- なし

## 動作確認

https://github.com/user-attachments/assets/cd6fbe1e-798f-48a6-9836-b0c5ecc1f9da


## その他

- なし
