### PR TITLE
save chat_history

### DIFF
--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -1,8 +1,6 @@
+import 'package:digit_kttn/chat/firestore_chat.dart';
 import 'package:flutter/material.dart';
-
-// void main() {
-//   runApp(const ChatApp());
-// }
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class ChatApp extends StatelessWidget {
   const ChatApp({super.key});
@@ -15,39 +13,47 @@ class ChatApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const ChatScreen(),
+      home: const ChatScreen(
+        stationId: 'station_123',
+      ),
     );
   }
 }
 
 class ChatScreen extends StatefulWidget {
-  const ChatScreen({super.key});
+  final String stationId;
+  const ChatScreen({super.key, required this.stationId});
 
   @override
   _ChatScreenState createState() => _ChatScreenState();
 }
 
 class _ChatScreenState extends State<ChatScreen> {
-  List<String> messages = [];
   List<String> choices = ["少ない・普通", "渋滞", "超渋滞"];
   final TextEditingController _textController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
 
-  void _handleChoice(String choice) {
-    setState(() {
-      messages.add("$choice");
-    });
+  void _sendMessage() async {
+    if (_textController.text.isEmpty) return;
+
+    await sendMessageToFirestore(
+      message: _textController.text,
+      crowdingLevel: "chat", // デフォルト値（ボタン選択時は変更）
+      stationId: "station_123",
+      userId: "user_456",
+    );
+
+    _textController.clear();
     _scrollToBottom();
   }
 
-  void _sendMessage() {
-    if (_textController.text.isEmpty) return;
-
-    setState(() {
-      messages.add("${_textController.text}");
-    });
-
-    _textController.clear();
+  void _handleChoice(String choice) async {
+    await sendMessageToFirestore(
+      message: "", // メッセージなし
+      crowdingLevel: choice,
+      stationId: "station_123",
+      userId: "user_456",
+    );
     _scrollToBottom();
   }
 
@@ -64,30 +70,60 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("会話")),
+      appBar: AppBar(title: Text("${widget.stationId} のチャット")),
       body: Column(
         children: [
           Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.all(10),
-              itemCount: messages.length,
-              itemBuilder: (context, index) {
-                return Align(
-                  alignment: messages[index].startsWith("あなた")
-                      ? Alignment.centerRight
-                      : Alignment.centerLeft,
-                  child: Container(
-                    margin: const EdgeInsets.symmetric(vertical: 5),
-                    padding: const EdgeInsets.all(10),
-                    decoration: BoxDecoration(
-                      color: messages[index].startsWith("あなた")
-                          ? Colors.blue[200]
-                          : Colors.grey[300],
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                    child: Text(messages[index]),
-                  ),
+            child: StreamBuilder<QuerySnapshot>(
+              stream: FirebaseFirestore.instance
+                  .collection('station_chats')
+                  .where('station_id', isEqualTo: widget.stationId)
+                  .where('crowding_level', isEqualTo: 'chat')
+                  .orderBy('created_message', descending: false) // 新着順にソート
+                  .snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if (snapshot.hasError) {
+                  print(snapshot);
+                  return const Center(child: Text('エラーが発生しました'));
+                }
+
+                if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                  print(snapshot);
+                  return const Center(child: Text('チャット履歴はありません'));
+                }
+
+                // Firestoreのデータをmessagesに格納
+                final chatData = snapshot.data!.docs;
+                final messages = chatData.map((doc) {
+                  return doc['message']?.toString() ?? ''; // 文字列に変換
+                }).toList();
+
+                return ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(10),
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    return Align(
+                      alignment: messages[index].startsWith("あなた")
+                          ? Alignment.centerRight
+                          : Alignment.centerLeft,
+                      child: Container(
+                        margin: const EdgeInsets.symmetric(vertical: 5),
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color: messages[index].startsWith("あなた")
+                              ? Colors.blue[200]
+                              : Colors.grey[300],
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Text(messages[index]),
+                      ),
+                    );
+                  },
                 );
               },
             ),
@@ -121,16 +157,16 @@ class _ChatScreenState extends State<ChatScreen> {
                   ),
                 ),
                 const SizedBox(width: 10),
-ElevatedButton(
-  onPressed: _sendMessage,
-  child: const Row(
-    mainAxisSize: MainAxisSize.min,
-    children: [
-      SizedBox(width: 5),
-      Text("送信"), // テキスト
-    ],
-  ),
-),
+                ElevatedButton(
+                  onPressed: _sendMessage,
+                  child: const Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(width: 5),
+                      Text("送信"), // テキスト
+                    ],
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/chat/firestore_chat.dart
+++ b/lib/chat/firestore_chat.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+Future<void> sendMessageToFirestore({
+  required String message,
+  required String crowdingLevel,
+  required String stationId,
+  required String userId,
+}) async {
+  final firestore = FirebaseFirestore.instance;
+  final chatId = "test_id_${DateTime.now().millisecondsSinceEpoch}"; // 一意のID
+  final timestamp = Timestamp.now();
+
+  await firestore.collection('station_chats').add({
+    'chat_id': chatId,
+    'created_message': timestamp,
+    'created_record': timestamp,
+    'crowding_level': crowdingLevel,
+    'message': message,
+    'station_id': stationId,
+    'user_id': userId,
+  });
+}
+
+Future<List<Map<String, dynamic>>> getChatHistoryForStation(
+    String stationId) async {
+  final firestore = FirebaseFirestore.instance;
+
+  // 'station_chats' コレクションから指定した station_id を持つチャット履歴を取得
+  QuerySnapshot querySnapshot = await firestore
+      .collection('station_chats')
+      .where('station_id', isEqualTo: stationId)
+      .where('crowding_level', isEqualTo: 'chat')
+      .orderBy('created_message', descending: true) // 新しいメッセージ順に並べる
+      .get();
+
+  // クエリ結果をリストに変換
+  List<Map<String, dynamic>> chatHistory = querySnapshot.docs.map((doc) {
+    return doc.data() as Map<String, dynamic>;
+  }).toList();
+
+  return chatHistory;
+}


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/28)

## やったこと

- チャットの履歴を保存する
- 履歴をリアルタイムで表示する
- 選択肢を選んだものはチャットに表示しない

## やらないこと

- なし

## できるようになること（ユーザ目線）

- チャットの履歴を保存

## できなくなること（ユーザ目線）

- なし

## 動作確認

https://github.com/user-attachments/assets/8ec0e262-8ca3-48da-9231-34224f7c4d0d

## その他

- なし
