### PR TITLE
add:1-hour-chat-history

### DIFF
--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -2,25 +2,10 @@ import 'package:digit_kttn/chat/firestore_chat.dart';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-class ChatApp extends StatelessWidget {
-  const ChatApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'Chat Choices',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: const ChatScreen(station_id: 0, name: ""),
-    );
-  }
-}
-
 class ChatScreen extends StatefulWidget {
   final int station_id;
   final String name;
+
   const ChatScreen({super.key, required this.station_id, required this.name});
 
   @override
@@ -28,16 +13,18 @@ class ChatScreen extends StatefulWidget {
 }
 
 class _ChatScreenState extends State<ChatScreen> {
-  List<String> choices = ["少ない・普通", "渋滞", "超渋滞"];
   final TextEditingController _textController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
+  final FirestoreChatService _chatService =
+      FirestoreChatService(); // 🔥 Firestoreサービスのインスタンス
 
+  /// **メッセージ送信**
   void _sendMessage() async {
     if (_textController.text.isEmpty) return;
 
-    await sendMessageToFirestore(
+    await _chatService.sendMessage(
       message: _textController.text,
-      crowdingLevel: "chat", // デフォルト値（ボタン選択時は変更）
+      crowdingLevel: "chat",
       stationId: widget.station_id,
       userId: "user_456",
     );
@@ -46,16 +33,7 @@ class _ChatScreenState extends State<ChatScreen> {
     _scrollToBottom();
   }
 
-  void _handleChoice(String choice) async {
-    await sendMessageToFirestore(
-      message: "", // メッセージなし
-      crowdingLevel: choice,
-      stationId: widget.station_id,
-      userId: "user_456",
-    );
-    _scrollToBottom();
-  }
-
+  /// **スクロールを一番下に移動**
   void _scrollToBottom() {
     Future.delayed(const Duration(milliseconds: 100), () {
       _scrollController.animateTo(
@@ -74,29 +52,22 @@ class _ChatScreenState extends State<ChatScreen> {
         children: [
           Expanded(
             child: StreamBuilder<QuerySnapshot>(
-              stream: FirebaseFirestore.instance
-                  .collection('station_chats')
-                  .where('station_id', isEqualTo: widget.station_id)
-                  .where('crowding_level', isEqualTo: 'chat')
-                  .orderBy('created_message', descending: false) // 新着順にソート
-                  .snapshots(),
+              stream: _chatService
+                  .getChatStream(widget.station_id), // 🔥 Firestoreデータ取得
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
                 }
-
                 if (snapshot.hasError) {
                   return const Center(child: Text('エラーが発生しました'));
                 }
-
                 if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-                  return const Center(child: Text('チャット履歴はありません'));
+                  return const Center(child: Text('1時間以内のチャット履歴はありません'));
                 }
 
-                // Firestoreのデータをmessagesに格納
                 final chatData = snapshot.data!.docs;
                 final messages = chatData.map((doc) {
-                  return doc['message']?.toString() ?? ''; // 文字列に変換
+                  return doc['message']?.toString() ?? '';
                 }).toList();
 
                 return ListView.builder(
@@ -125,20 +96,6 @@ class _ChatScreenState extends State<ChatScreen> {
               },
             ),
           ),
-          const Divider(height: 1),
-          Padding(
-            padding: const EdgeInsets.all(10),
-            child: Wrap(
-              alignment: WrapAlignment.center,
-              spacing: 10,
-              children: choices.map((choice) {
-                return ElevatedButton(
-                  onPressed: () => _handleChoice(choice),
-                  child: Text(choice),
-                );
-              }).toList(),
-            ),
-          ),
           Padding(
             padding: const EdgeInsets.all(10),
             child: Row(
@@ -156,13 +113,7 @@ class _ChatScreenState extends State<ChatScreen> {
                 const SizedBox(width: 10),
                 ElevatedButton(
                   onPressed: _sendMessage,
-                  child: const Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(width: 5),
-                      Text("送信"), // テキスト
-                    ],
-                  ),
+                  child: const Text("送信"),
                 ),
               ],
             ),

--- a/lib/chat/firestore_chat.dart
+++ b/lib/chat/firestore_chat.dart
@@ -1,43 +1,42 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-Future<void> sendMessageToFirestore({
-  required String message,
-  required String crowdingLevel,
-  required int stationId,
-  required String userId,
-}) async {
-  final firestore = FirebaseFirestore.instance;
-  final chatId = "test_id_${DateTime.now().millisecondsSinceEpoch}"; // 一意のID
-  final timestamp = Timestamp.now();
+class FirestoreChatService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-  await firestore.collection('station_chats').add({
-    'chat_id': chatId,
-    'created_message': timestamp,
-    'created_record': timestamp,
-    'crowding_level': crowdingLevel,
-    'message': message,
-    'station_id': stationId,
-    'user_id': userId,
-  });
-}
+  /// **メッセージを Firestore に送信**
+  Future<void> sendMessage({
+    required String message,
+    required String crowdingLevel,
+    required int stationId,
+    required String userId,
+  }) async {
+    final chatId = "test_id_${DateTime.now().millisecondsSinceEpoch}";
+    final timestamp = Timestamp.now();
 
-Future<List<Map<String, dynamic>>> getChatHistoryForStation(
-    int stationId) async {
-  final firestore = FirebaseFirestore.instance;
+    await _firestore.collection('station_chats').add({
+      'chat_id': chatId,
+      'created_message': timestamp,
+      'created_record': timestamp,
+      'crowding_level': crowdingLevel,
+      'message': message,
+      'station_id': stationId,
+      'user_id': userId,
+    });
+  }
 
-  // 'station_chats' コレクションから指定した station_id を持つチャット履歴を取得
-  QuerySnapshot querySnapshot = await firestore
-      .collection('station_chats')
-      .where('station_id',
-          isEqualTo: int.parse(stationId as String)) // ここで int 型を使います
-      .where('crowding_level', isEqualTo: 'chat')
-      .orderBy('created_message', descending: true) // 新しいメッセージ順に並べる
-      .get();
+  /// **リアルタイムで1時間以内のチャット履歴を取得**
+  Stream<QuerySnapshot> getChatStream(int stationId) {
+    Timestamp oneHourAgo = Timestamp.fromMillisecondsSinceEpoch(
+      DateTime.now().subtract(const Duration(hours: 1)).millisecondsSinceEpoch,
+    );
 
-  // クエリ結果をリストに変換
-  List<Map<String, dynamic>> chatHistory = querySnapshot.docs.map((doc) {
-    return doc.data() as Map<String, dynamic>;
-  }).toList();
-
-  return chatHistory;
+    return _firestore
+        .collection('station_chats')
+        .where('station_id', isEqualTo: stationId)
+        .where('crowding_level', isEqualTo: 'chat')
+        .where('created_record', isGreaterThanOrEqualTo: oneHourAgo)
+        .orderBy('created_record', descending: false)
+        .orderBy('created_message', descending: false)
+        .snapshots();
+  }
 }


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/32)

## やったこと

- 1時間以内のチャットの履歴を取得

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 1時間以内のチャットの履歴を見ること

## できなくなること（ユーザ目線）

- 1時間以上のチャットの履歴を見ること

## 動作確認

<img width="499" alt="スクリーンショット 2025-03-13 13 57 09" src="https://github.com/user-attachments/assets/ba06b5f4-8030-474e-936d-20bad5369b27" />
<img width="497" alt="スクリーンショット 2025-03-13 13 57 00" src="https://github.com/user-attachments/assets/96a8bbce-0c5e-4b57-ab12-4a259f797afd" />

## その他

- なし