### PR TITLE
add:1-hour-marker-color

### DIFF
--- a/lib/map/map_screen.dart
+++ b/lib/map/map_screen.dart
@@ -33,9 +33,36 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   // Firestoreから混雑情報をリッスン
+  // void listenToCrowdingUpdates() {
+  //   FirebaseFirestore.instance
+  //       .collection('station_chats')
+  //       .snapshots()
+  //       .listen((snapshot) {
+  //     Map<String, List<String>> stationCrowdingData = {};
+
+  //     for (var doc in snapshot.docs) {
+  //       String stationId = doc['station_id'].toString();
+  //       String crowdingLevel = doc['crowding_level'];
+
+  //       if (!stationCrowdingData.containsKey(stationId)) {
+  //         stationCrowdingData[stationId] = [];
+  //       }
+  //       stationCrowdingData[stationId]!.add(crowdingLevel);
+  //     }
+
+  //     updateMarkers(stationCrowdingData);
+  //   });
+  // }
+
   void listenToCrowdingUpdates() {
+    final now = Timestamp.now();
+    final oneHourAgo = Timestamp.fromMillisecondsSinceEpoch(
+        now.millisecondsSinceEpoch - 3600 * 1000);
+
     FirebaseFirestore.instance
         .collection('station_chats')
+        .where('created_record',
+            isGreaterThanOrEqualTo: oneHourAgo) // 1時間以内のデータのみ取得
         .snapshots()
         .listen((snapshot) {
       Map<String, List<String>> stationCrowdingData = {};

--- a/lib/map/marker_color.dart
+++ b/lib/map/marker_color.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 
 String getMajorityCrowdingLevel(List<String> levels) {
+  if (levels.isEmpty) {
+    return '投稿なし'; // 投稿がない場合は黒
+  }
+
   Map<String, int> count = {'超渋滞': 0, '渋滞': 0, '少ない・普通': 0};
 
   for (var level in levels) {
@@ -26,7 +30,10 @@ Color getMarkerColor(String level) {
     case "渋滞":
       return Colors.orange; // 渋滞
     case "少ない・普通":
+      return Colors.green;
+    case "投稿なし":
+      return Colors.black;
     default:
-      return Colors.green; // 少ない・普通
+      return Colors.black;
   }
 }


### PR DESCRIPTION
## issue のリンク

- [issue](https://github.com/DIGIT-KITAQ-Flutter/team_kttn/issues/40)

## やったこと

- 混雑状況の把握は1時間以内の投稿から
- 1時間何も投稿がない場合はマーカーの色は黒色

## やらないこと

- なし

## できるようになること（ユーザ目線）

- リアルタイムの混雑状況把握

## できなくなること（ユーザ目線）

- なし

## 動作確認

<img width="498" alt="スクリーンショット 2025-03-13 17 53 27" src="https://github.com/user-attachments/assets/d8dc327c-7c00-4021-bb0c-561250ad6af9" />


## その他

- なし
